### PR TITLE
Adding size variable/parameter to libvirt modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "controlplane_nodes" {
   cloud_init_network_config = var.cloud_init_network_config != "" ? var.cloud_init_network_config : data.template_file.network_config.rendered
   cloud_init_user_data = var.cloud_init_user_data != "" ? var.cloud_init_user_data : data.template_file.user_data.rendered
   pool = var.pool
+  size = var.controlplane_vol_size
 }
 
 module "nodes" {
@@ -26,6 +27,7 @@ module "nodes" {
   cloud_init_network_config = var.cloud_init_network_config != "" ? var.cloud_init_network_config : data.template_file.network_config.rendered
   cloud_init_user_data = var.cloud_init_user_data != "" ? var.cloud_init_user_data : data.template_file.user_data.rendered
   pool = var.pool
+  size = var.dataplane_vol_size
 
   depends_on = [
     module.controlplane_nodes

--- a/modules/controlplanes/main.tf
+++ b/modules/controlplanes/main.tf
@@ -4,6 +4,7 @@ resource "libvirt_volume" "this" {
   pool   = var.pool
   source = var.os_source
   format = "qcow2"
+  size = var.size
 }
 
 resource "libvirt_cloudinit_disk" "this" {

--- a/modules/controlplanes/variables.tf
+++ b/modules/controlplanes/variables.tf
@@ -36,3 +36,9 @@ variable "os_source" {
 variable "pool" {
   description = "The storage pool where the controlplane volumes will be created"
 }
+
+variable "size" {
+  description = "The size in bytes of the controlplane volume (must be in 1073741824 bytes not 10MB, 10GB) Defaults to 10GB (in bytes)."
+  type = string
+  default = "10737418240"
+}

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -4,6 +4,7 @@ resource "libvirt_volume" "this" {
   pool   = var.pool
   source = var.os_source
   format = "qcow2"
+  size = var.size
 }
 
 resource "libvirt_cloudinit_disk" "this" {

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -37,3 +37,9 @@ variable "pool" {
   description = "The storage pool where the dataplane volumes will be created"
   type = string
 }
+
+variable "size" {
+  description = "The size in bytes of the dataplane volume (must be in 1073741824 bytes not 10MB, 10GB) Defaults to 10GB (in bytes)."
+  type = string
+  default = "10737418240"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,15 @@ variable "pool" {
   description = "The libvirt pool to store node disks/volumes"
   type = string
 }
+
+variable "controlplane_vol_size" {
+  description = "The size in bytes of the controlplane volume (must be in 1073741824 bytes not 10MB, 10GB) Defaults to 10GB (in bytes)."
+  type = string
+  default = "10737418240"
+}
+
+variable "dataplane_vol_size" {
+  description = "The size in bytes of the dataplane volume (must be in 1073741824 bytes not 10MB, 10GB) Defaults to 10GB (in bytes)."
+  type = string
+  default = "10737418240"
+}


### PR DESCRIPTION
Adding a size param for the `libvirt_volume` Terraform resource

https://registry.terraform.io/providers/multani/libvirt/latest/docs/resources/volume

this is so we can change the size of the node volumes